### PR TITLE
feat: Add global footer with privacy policy and social links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,20 +1,28 @@
-import React from "react";
+import React, { useState } from "react";
 import { AuthProvider } from "./context/AuthContext";
 import { JournalProvider } from "./context/JournalContext";
 import { Navbar } from "./components/Navbar";
 import { BookContainer } from "./components/Book/BookContainer";
+import { Footer } from "./components/Footer";
+import { PrivacyModal } from "./components/PrivacyModal";
 
 function App() {
+  const [showPrivacy, setShowPrivacy] = useState(false);
+
   return (
     <AuthProvider>
       <JournalProvider>
         <div
-          className="min-h-screen font-body antialiased"
+          className="min-h-screen flex flex-col font-body antialiased"
           style={{ background: "var(--bg)", color: "var(--text-primary)" }}
         >
           <Navbar />
-          <BookContainer />
+          <div className="flex-grow relative flex flex-col justify-center">
+            <BookContainer />
+          </div>
+          <Footer onOpenPrivacy={() => setShowPrivacy(true)} />
         </div>
+        <PrivacyModal isOpen={showPrivacy} onClose={() => setShowPrivacy(false)} />
       </JournalProvider>
     </AuthProvider>
   );

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Github, Linkedin, Shield, Globe } from 'lucide-react';
+
+export const Footer = ({ onOpenPrivacy }) => {
+  return (
+    <footer className="w-full py-6 mt-auto border-t z-10 relative" style={{ borderColor: 'var(--border)', background: 'var(--bg)' }}>
+      <div className="max-w-5xl mx-auto px-4 flex flex-col md:flex-row justify-between items-center gap-4">
+        <div className="text-xs" style={{ color: 'var(--text-tertiary)' }}>
+          © {new Date().getFullYear()} Mariyam. Built with React & Supabase.
+        </div>
+        
+        <div className="flex items-center gap-6">
+          <button 
+            onClick={onOpenPrivacy}
+            className="flex items-center gap-1.5 text-xs transition-colors hover:text-white"
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            <Shield size={14} />
+            Privacy Policy
+          </button>
+          
+          <a 
+            href="https://mariyamalikhokhar.com/" 
+            target="_blank" 
+            rel="noreferrer"
+            className="flex items-center gap-1.5 text-xs transition-colors hover:text-white"
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            <Globe size={14} />
+            Website
+          </a>
+
+          <a 
+            href="https://github.com/Mariyamalikho" 
+            target="_blank" 
+            rel="noreferrer"
+            className="flex items-center gap-1.5 text-xs transition-colors hover:text-white"
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            <Github size={14} />
+            GitHub
+          </a>
+
+          <a 
+            href="https://www.linkedin.com/in/mariyamali-khokhar/" 
+            target="_blank" 
+            rel="noreferrer"
+            className="flex items-center gap-1.5 text-xs transition-colors hover:text-white"
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            <Linkedin size={14} />
+            LinkedIn
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+};

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Github, Linkedin, Shield, Globe } from 'lucide-react';
+import { Shield, Globe } from 'lucide-react';
 
 export const Footer = ({ onOpenPrivacy }) => {
   return (
@@ -37,7 +37,9 @@ export const Footer = ({ onOpenPrivacy }) => {
             className="flex items-center gap-1.5 text-xs transition-colors hover:text-white"
             style={{ color: 'var(--text-secondary)' }}
           >
-            <Github size={14} />
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
+            </svg>
             GitHub
           </a>
 
@@ -48,7 +50,11 @@ export const Footer = ({ onOpenPrivacy }) => {
             className="flex items-center gap-1.5 text-xs transition-colors hover:text-white"
             style={{ color: 'var(--text-secondary)' }}
           >
-            <Linkedin size={14} />
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z" />
+              <rect x="2" y="9" width="4" height="12" />
+              <circle cx="4" cy="4" r="2" />
+            </svg>
             LinkedIn
           </a>
         </div>

--- a/src/components/PrivacyModal.jsx
+++ b/src/components/PrivacyModal.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { X, Shield } from 'lucide-react';
+
+export const PrivacyModal = ({ isOpen, onClose }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm animate-fade-in">
+      <div className="w-full max-w-2xl max-h-[85vh] overflow-y-auto rounded-[24px] p-8 shadow-2xl relative animate-scale-in" style={{ background: 'var(--surface-1)', border: '1px solid var(--border)' }}>
+        <button
+          onClick={onClose}
+          className="absolute top-6 right-6 p-2 rounded-full transition-colors hover:text-white"
+          style={{ background: 'var(--surface-2)', color: 'var(--text-secondary)' }}
+        >
+          <X size={18} />
+        </button>
+
+        <div className="flex items-center gap-3 mb-6">
+          <div className="p-2 rounded-xl" style={{ background: 'rgba(108, 99, 255, 0.1)', color: '#6c63ff' }}>
+            <Shield size={24} />
+          </div>
+          <h2 className="text-2xl font-serifTitle" style={{ color: 'var(--text-primary)' }}>Privacy Policy</h2>
+        </div>
+        
+        <div className="space-y-6 text-sm" style={{ color: 'var(--text-secondary)', lineHeight: '1.7' }}>
+          <p>Last updated: August 2026</p>
+          
+          <div>
+            <h3 className="text-lg font-medium mb-2" style={{ color: 'var(--text-primary)' }}>1. Data Collection</h3>
+            <p>We only collect the information necessary to provide you with your digital commonplace book. This includes your email address (for authentication) and the text, drawings, and media you explicitly save in your journals.</p>
+          </div>
+          
+          <div>
+            <h3 className="text-lg font-medium mb-2" style={{ color: 'var(--text-primary)' }}>2. Data Storage & Security</h3>
+            <p>All journal entries are stored securely using Supabase. We implement strict Row Level Security (RLS) policies ensuring that only you (and people you explicitly share edit access with) can access your private journal entries. No other users can read or write to your book.</p>
+          </div>
+          
+          <div>
+            <h3 className="text-lg font-medium mb-2" style={{ color: 'var(--text-primary)' }}>3. Cookies & Tracking</h3>
+            <p>We use local storage strictly for maintaining your session state (keeping you logged in) and remembering your UI preferences (like dark mode). We do not use third-party tracking cookies or advertising pixels.</p>
+          </div>
+          
+          <div>
+            <h3 className="text-lg font-medium mb-2" style={{ color: 'var(--text-primary)' }}>4. Account Deletion</h3>
+            <p>You can request account deletion at any time. Upon deletion, all associated journals, pages, and media files will be permanently removed from our databases and storage buckets.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Fixes #52

Added a global `Footer` to the bottom of the main application layout (`App.jsx`).
The footer includes a dynamic copyright year, and direct links to the user's personal website, GitHub, and LinkedIn profiles as requested.

Also added a `PrivacyModal` component which opens when clicking "Privacy Policy" in the footer. It details the app's data collection, storage, and RLS security practices to reassure users.
