### PR TITLE
ui: Make book layout mobile responsive

### DIFF
--- a/src/components/Book/BookCover.jsx
+++ b/src/components/Book/BookCover.jsx
@@ -85,11 +85,10 @@ export const BookCover = ({ isPreview = false }) => {
   return (
     <div className="w-full max-w-[480px] mx-auto px-4 py-8 md:py-12 animate-fade-in">
       <div
+        className="relative w-full max-w-[480px] mx-auto rounded-r-[24px] rounded-l-[4px] p-8 md:p-12 overflow-hidden group select-none flex flex-col items-center justify-center cursor-pointer min-h-[500px] md:min-h-[620px]"
         onClick={handleOpenAttempt}
-        className="relative rounded-r-[24px] rounded-l-[4px] overflow-hidden cursor-pointer group"
         style={{
           background: coverBg,
-          minHeight: '620px',
           boxShadow: `
             0 0 0 1px rgba(255,255,255,0.05),
             0 2px 1px rgba(255,255,255,0.06) inset,

--- a/src/components/Book/PageContent.jsx
+++ b/src/components/Book/PageContent.jsx
@@ -79,7 +79,7 @@ export const PageContent = ({ page, side = 'left' }) => {
 
   return (
     <div
-      className="relative h-[580px] md:h-[640px] max-h-[640px] p-5 pb-[22px] md:p-8 md:pb-[34px] lined-paper flex flex-col justify-between overflow-hidden"
+      className="relative h-[480px] md:h-[640px] max-h-[640px] p-5 pb-[22px] md:p-8 md:pb-[34px] lined-paper flex flex-col justify-between overflow-hidden"
       style={{ 
         color: 'var(--ink-mid)', 
         boxShadow: side === 'left' 
@@ -158,7 +158,7 @@ export const PageContent = ({ page, side = 'left' }) => {
       </div>
 
       {/* ── SCROLLABLE CONTENT ── */}
-      <div className="relative z-20 flex-grow flex flex-col my-1 overflow-y-auto pr-1 space-y-2 max-h-[440px]">
+      <div className="relative z-20 flex-grow flex flex-col my-1 overflow-y-auto pr-1 space-y-2 max-h-[320px] md:max-h-[440px]">
         {/* Title */}
         <div className="border-b pb-2 shrink-0" style={{ borderColor: 'var(--parchment-line)' }}>
           {canWrite ? (


### PR DESCRIPTION
Fixes #54

**Changes:**
- Updated the `BookCover` container to use responsive height classes (`min-h-[500px] md:min-h-[620px]`) instead of a hardcoded inline style.
- Updated the `PageContent` container to use responsive height classes (`h-[480px] md:h-[640px]`).
- Adjusted the scrollable content container's `max-h` to ensure it still fits perfectly on smaller devices.

The journal will now appear much shorter and fit naturally on mobile screens while maintaining its original majestic size on desktop and tablets!
