### PR TITLE
ui: Radically reduce vertical padding and heights for smaller phones

### DIFF
--- a/src/components/Book/BookContainer.jsx
+++ b/src/components/Book/BookContainer.jsx
@@ -67,7 +67,7 @@ export const BookContainer = () => {
 
   return (
     <main
-      className="min-h-screen pt-14 pb-24 px-2 flex flex-col items-center transition-all duration-700"
+      className="min-h-screen pt-4 pb-8 md:pt-14 md:pb-24 px-2 flex flex-col items-center transition-all duration-700"
       style={{ background: getAmbientBg() }}
     >
       <PageSpread />

--- a/src/components/Book/BookCover.jsx
+++ b/src/components/Book/BookCover.jsx
@@ -85,7 +85,7 @@ export const BookCover = ({ isPreview = false }) => {
   return (
     <div className="w-full max-w-[480px] mx-auto px-4 py-8 md:py-12 animate-fade-in">
       <div
-        className="relative w-full max-w-[480px] mx-auto rounded-r-[24px] rounded-l-[4px] p-8 md:p-12 overflow-hidden group select-none flex flex-col items-center justify-center cursor-pointer min-h-[500px] md:min-h-[620px]"
+        className="relative w-full max-w-[480px] mx-auto rounded-r-[24px] rounded-l-[4px] p-8 md:p-12 overflow-hidden group select-none flex flex-col items-center justify-center cursor-pointer min-h-[400px] md:min-h-[620px]"
         onClick={handleOpenAttempt}
         style={{
           background: coverBg,

--- a/src/components/Book/PageContent.jsx
+++ b/src/components/Book/PageContent.jsx
@@ -79,7 +79,7 @@ export const PageContent = ({ page, side = 'left' }) => {
 
   return (
     <div
-      className="relative h-[480px] md:h-[640px] max-h-[640px] p-5 pb-[22px] md:p-8 md:pb-[34px] lined-paper flex flex-col justify-between overflow-hidden"
+      className="relative h-[400px] sm:h-[480px] md:h-[640px] max-h-[640px] p-5 pb-[22px] md:p-8 md:pb-[34px] lined-paper flex flex-col justify-between overflow-hidden"
       style={{ 
         color: 'var(--ink-mid)', 
         boxShadow: side === 'left' 


### PR DESCRIPTION
Fixes #56

**Changes:**
- Radically reduced the `BookContainer` vertical padding on mobile from `pt-14 pb-24` (152px total padding) to `pt-4 pb-8` (48px total padding), freeing up over 100px of screen real estate.
- Shrunk the `BookCover` mobile height from `500px` to `400px`.
- Shrunk the `PageContent` mobile height from `480px` to `400px`.
- Added an intermediate `sm:h-[480px]` step for mid-sized phones, retaining `640px` for desktop.

This combination of shrinking the book by another 100px AND removing 100px of excessive padding ensures the book will completely fit within the viewport on small devices like the iPhone SE without pushing the footer off-screen!
