### PR TITLE
ui: Implement perfect responsive aspect ratio and fix vertical alignment

### DIFF
--- a/src/components/Book/BookContainer.jsx
+++ b/src/components/Book/BookContainer.jsx
@@ -67,7 +67,7 @@ export const BookContainer = () => {
 
   return (
     <main
-      className="min-h-screen pt-4 pb-8 md:pt-14 md:pb-24 px-2 flex flex-col items-center transition-all duration-700"
+      className="flex-1 w-full py-6 md:py-12 px-2 flex flex-col items-center justify-center transition-all duration-700"
       style={{ background: getAmbientBg() }}
     >
       <PageSpread />

--- a/src/components/Book/BookCover.jsx
+++ b/src/components/Book/BookCover.jsx
@@ -85,7 +85,7 @@ export const BookCover = ({ isPreview = false }) => {
   return (
     <div className="w-full max-w-[480px] mx-auto px-4 py-8 md:py-12 animate-fade-in">
       <div
-        className="relative w-full max-w-[480px] mx-auto rounded-r-[24px] rounded-l-[4px] p-8 md:p-12 overflow-hidden group select-none flex flex-col items-center justify-center cursor-pointer min-h-[400px] md:min-h-[620px]"
+        className="relative w-full max-w-[480px] mx-auto rounded-r-[24px] rounded-l-[4px] p-8 md:p-12 overflow-hidden group select-none flex flex-col items-center justify-center cursor-pointer aspect-[3/4]"
         onClick={handleOpenAttempt}
         style={{
           background: coverBg,

--- a/src/components/Book/PageContent.jsx
+++ b/src/components/Book/PageContent.jsx
@@ -79,7 +79,7 @@ export const PageContent = ({ page, side = 'left' }) => {
 
   return (
     <div
-      className="relative h-[400px] sm:h-[480px] md:h-[640px] max-h-[640px] p-5 pb-[22px] md:p-8 md:pb-[34px] lined-paper flex flex-col justify-between overflow-hidden"
+      className="relative aspect-[3/4] p-5 pb-[22px] md:p-8 md:pb-[34px] lined-paper flex flex-col justify-between overflow-hidden"
       style={{ 
         color: 'var(--ink-mid)', 
         boxShadow: side === 'left' 
@@ -158,7 +158,7 @@ export const PageContent = ({ page, side = 'left' }) => {
       </div>
 
       {/* ── SCROLLABLE CONTENT ── */}
-      <div className="relative z-20 flex-grow flex flex-col my-1 overflow-y-auto pr-1 space-y-2 max-h-[320px] md:max-h-[440px]">
+      <div className="relative z-20 flex-grow flex flex-col my-1 overflow-y-auto pr-1 space-y-2">
         {/* Title */}
         <div className="border-b pb-2 shrink-0" style={{ borderColor: 'var(--parchment-line)' }}>
           {canWrite ? (


### PR DESCRIPTION
Fixes #58

**The True UI/UX Fix for Responsiveness**

The previous attempts were flawed because they relied on hardcoded pixel heights (`400px`, `480px`, etc.), which squished the book's natural shape on mobile devices and looked unprofessional. Additionally, the outer `BookContainer` was using `min-h-screen`, which caused the entire page to overflow vertically once the Navbar and Footer were introduced, breaking the centered alignment.

**Changes in this PR:**
1. **Perfect Aspect Ratio:** Removed all hardcoded `h-[...]` pixel classes from the `BookCover` and `PageContent` and replaced them with Tailwind's `aspect-[3/4]`. The book will now perfectly scale its height proportionally to its width on ANY device size, maintaining the exact physical shape of a real journal.
2. **Fixed Scroll Constraints:** Removed the `max-h-[320px]` limit on the inner scrollable text area. Because the parent container now uses `aspect-[3/4]`, standard flex-grow handles the scrolling bounds perfectly.
3. **Fixed Alignment:** Refactored `BookContainer` to use `flex-1 w-full justify-center` instead of `min-h-screen`. This forces the book to sit perfectly centered in the exact available space between the Navbar and Footer, eliminating the ugly double scrollbars on the main window.
