### PR TITLE
Feature: Support multiple journals and fix missing mobile actions

### DIFF
--- a/src/components/Controls/ManageJournalsModal.jsx
+++ b/src/components/Controls/ManageJournalsModal.jsx
@@ -1,0 +1,136 @@
+import React, { useState } from 'react';
+import { BookOpen, Plus, Trash2, X } from 'lucide-react';
+import { useJournal } from '../../context/JournalContext';
+import { useAuth } from '../../context/AuthContext';
+
+export const ManageJournalsModal = ({ isOpen, onClose }) => {
+  const { userBooks, currentBook, switchBook, createNewBook, deleteBook, role } = useJournal();
+  const { user } = useAuth();
+  const [newTitle, setNewTitle] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    if (!newTitle.trim()) return;
+    setIsCreating(true);
+    try {
+      await createNewBook(newTitle.trim());
+      setNewTitle('');
+      onClose(); // Optional: close modal after creating to drop them right into the new book
+    } catch (error) {
+      alert(error.message);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleDelete = async (e, book) => {
+    e.stopPropagation();
+    if (confirm(`Are you sure you want to delete "${book.title}"? This cannot be undone.`)) {
+      try {
+        await deleteBook(book.id);
+      } catch (error) {
+        alert(error.message);
+      }
+    }
+  };
+
+  const handleSwitch = (bookId) => {
+    switchBook(bookId);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div 
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div 
+        className="relative w-full max-w-md rounded-[20px] shadow-2xl overflow-hidden animate-fade-in-up"
+        style={{ background: 'var(--surface-1)', border: '1px solid var(--border)' }}
+      >
+        <div className="flex items-center justify-between p-6 border-b" style={{ borderColor: 'var(--border)' }}>
+          <h2 className="text-xl font-serifTitle" style={{ color: 'var(--text-primary)' }}>Manage Journals</h2>
+          <button 
+            onClick={onClose}
+            className="p-1 rounded-full hover:bg-white/5 transition-colors"
+            style={{ color: 'var(--text-tertiary)' }}
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="p-6">
+          <div className="space-y-2 max-h-[300px] overflow-y-auto mb-6 pr-2 custom-scrollbar">
+            {userBooks.map(book => {
+              const isCurrent = currentBook?.id === book.id;
+              const isOwner = book.ownerId === user?.id;
+              return (
+                <div 
+                  key={book.id}
+                  onClick={() => handleSwitch(book.id)}
+                  className={`flex items-center justify-between p-3 rounded-[12px] cursor-pointer transition-all ${isCurrent ? 'ring-1' : 'hover:bg-white/5'}`}
+                  style={{ 
+                    background: isCurrent ? 'var(--surface-2)' : 'transparent',
+                    ringColor: isCurrent ? 'var(--accent)' : 'transparent'
+                  }}
+                >
+                  <div className="flex items-center gap-3 overflow-hidden">
+                    <BookOpen size={16} style={{ color: isCurrent ? 'var(--accent)' : 'var(--text-secondary)' }} />
+                    <div className="flex flex-col overflow-hidden">
+                      <span className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>
+                        {book.title}
+                      </span>
+                      <span className="text-xs truncate" style={{ color: 'var(--text-tertiary)' }}>
+                        {isOwner ? 'Owner' : 'Shared'}
+                      </span>
+                    </div>
+                  </div>
+                  
+                  {isOwner && userBooks.length > 1 && (
+                    <button 
+                      onClick={(e) => handleDelete(e, book)}
+                      className="p-2 rounded-md hover:bg-red-500/10 transition-colors"
+                      style={{ color: 'var(--text-tertiary)' }}
+                      onMouseEnter={e => e.currentTarget.style.color = '#ef4444'}
+                      onMouseLeave={e => e.currentTarget.style.color = 'var(--text-tertiary)'}
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          <form onSubmit={handleCreate} className="flex gap-2">
+            <input
+              type="text"
+              value={newTitle}
+              onChange={e => setNewTitle(e.target.value)}
+              placeholder="New journal title..."
+              className="flex-1 px-4 py-2 text-sm rounded-[10px] outline-none transition-all"
+              style={{ background: 'var(--surface-2)', border: '1px solid var(--border)', color: 'var(--text-primary)' }}
+              disabled={isCreating}
+            />
+            <button
+              type="submit"
+              disabled={!newTitle.trim() || isCreating}
+              className="px-4 py-2 rounded-[10px] text-sm font-medium flex items-center gap-2 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{ background: 'var(--accent)', color: '#fff' }}
+            >
+              <Plus size={16} />
+              {isCreating ? 'Creating...' : 'Create'}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { BookOpen, ChevronDown, LogOut, Settings, Plus, Scissors, Palette } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { useJournal } from '../context/JournalContext';
+import { ManageJournalsModal } from './Controls/ManageJournalsModal';
 
 export const Navbar = () => {
   const { user, setAuthModalOpen, setAuthMode, setAccountModalOpen, logout } = useAuth();
@@ -17,9 +18,11 @@ export const Navbar = () => {
   } = useJournal();
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [manageJournalsModalOpen, setManageJournalsModalOpen] = useState(false);
   const avatarLetter = user ? (user.name?.[0] || user.email?.[0] || 'S').toUpperCase() : '?';
 
   return (
+    <>
     <nav
       className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-4 md:px-6 h-14"
       style={{
@@ -33,47 +36,49 @@ export const Navbar = () => {
 
       {/* Center — Book title + page actions */}
       {currentBook && (
-        <div className="flex items-center gap-2">
-          {/* Book title pill */}
-          <div
-            className="hidden md:flex items-center gap-1.5 px-3 py-1 rounded-[8px] text-xs"
+        <div className="flex items-center gap-1 md:gap-2">
+          {/* Book title pill (Button to open Manage Journals) */}
+          <button
+            onClick={() => setManageJournalsModalOpen(true)}
+            className="flex items-center gap-1.5 px-2 md:px-3 py-1 rounded-[8px] text-xs transition-colors hover:bg-white/5"
             style={{ background: 'var(--surface-2)', border: '1px solid var(--border)', color: 'var(--text-secondary)' }}
           >
             <BookOpen size={11} />
-            <span className="max-w-[160px] truncate" style={{ color: 'var(--text-primary)' }}>
+            <span className="max-w-[80px] md:max-w-[160px] truncate" style={{ color: 'var(--text-primary)' }}>
               {currentBook.title}
             </span>
-          </div>
+            <ChevronDown size={11} className="opacity-50" />
+          </button>
 
           {canWrite && (
             <>
               <button
                 onClick={addSpread}
-                className="hidden md:flex items-center gap-1.5 px-2.5 py-1 rounded-[8px] text-xs transition-all"
+                className="flex items-center gap-1.5 px-2 md:px-2.5 py-1 rounded-[8px] text-xs transition-all"
                 style={{ background: 'var(--surface-2)', border: '1px solid var(--border)', color: 'var(--text-secondary)' }}
                 onMouseEnter={e => e.currentTarget.style.color = 'var(--text-primary)'}
                 onMouseLeave={e => e.currentTarget.style.color = 'var(--text-secondary)'}
+                title="Add Pages"
               >
                 <Plus size={11} />
-                <span>Add Pages</span>
+                <span className="hidden md:inline">Add Pages</span>
               </button>
 
               {currentSpreadIndex > 0 && (
                 <button
                   onClick={tearCurrentSpread}
-                  className="hidden md:flex items-center gap-1.5 px-2.5 py-1 rounded-[8px] text-xs transition-all"
+                  className="flex items-center gap-1.5 px-2 md:px-2.5 py-1 rounded-[8px] text-xs transition-all"
                   style={{ background: 'var(--surface-2)', border: '1px solid var(--border)', color: 'rgba(239,68,68,0.6)' }}
                   onMouseEnter={e => e.currentTarget.style.color = '#ef4444'}
                   onMouseLeave={e => e.currentTarget.style.color = 'rgba(239,68,68,0.6)'}
+                  title="Tear Pages"
                 >
                   <Scissors size={11} />
-                  <span>Tear</span>
+                  <span className="hidden md:inline">Tear</span>
                 </button>
               )}
-
             </>
           )}
-
         </div>
       )}
 
@@ -159,5 +164,7 @@ export const Navbar = () => {
         )}
       </div>
     </nav>
+    <ManageJournalsModal isOpen={manageJournalsModalOpen} onClose={() => setManageJournalsModalOpen(false)} />
+    </>
   );
 };

--- a/src/context/JournalContext.jsx
+++ b/src/context/JournalContext.jsx
@@ -9,7 +9,9 @@ import {
   supabaseGetUserBooks, 
   supabaseJoinBookViaToken, 
   supabaseSaveBook, 
-  supabaseUpdateBookViaToken 
+  supabaseUpdateBookViaToken,
+  supabaseCreateNewBook,
+  supabaseDeleteBook
 } from '../services/supabaseService';
 import { versionService } from '../services/versionService';
 
@@ -460,6 +462,37 @@ export const JournalProvider = ({ children }) => {
     setCurrentSpreadIndex(0);
   };
 
+  const createNewBook = async (title) => {
+    if (!user) return;
+    try {
+      const newBook = await supabaseCreateNewBook(user, title);
+      setUserBooks(prev => [newBook, ...prev]);
+      setCurrentBook(newBook);
+      setCurrentSpreadIndex(0);
+      return newBook;
+    } catch (error) {
+      console.error("Error creating new book:", error);
+      throw error;
+    }
+  };
+
+  const deleteBook = async (bookId) => {
+    if (!user) return;
+    try {
+      const success = await supabaseDeleteBook(bookId);
+      if (!success) throw new Error("Failed to delete book from database.");
+      const updatedBooks = userBooks.filter(b => b.id !== bookId);
+      setUserBooks(updatedBooks);
+      if (currentBook?.id === bookId) {
+        setCurrentBook(updatedBooks.length > 0 ? updatedBooks[0] : null);
+        setCurrentSpreadIndex(0);
+      }
+    } catch (error) {
+      console.error("Error deleting book:", error);
+      throw error;
+    }
+  };
+
   return (
     <JournalContext.Provider value={{
       userBooks,
@@ -514,7 +547,9 @@ export const JournalProvider = ({ children }) => {
       setGuestName,
       hasSeenGuestUpsell,
       setHasSeenGuestUpsell,
-      leaveBook
+      leaveBook,
+      createNewBook,
+      deleteBook
     }}>
       {children}
     </JournalContext.Provider>

--- a/src/services/supabaseService.js
+++ b/src/services/supabaseService.js
@@ -149,6 +149,27 @@ export const supabaseGetUserBooks = async (user) => {
   return data;
 };
 
+export const supabaseCreateNewBook = async (user, title = "New Journal") => {
+  if (!supabase || !user) throw new Error("Not authenticated");
+  
+  const newBook = {
+    ...DEFAULT_INITIAL_BOOK,
+    id: crypto.randomUUID(),
+    ownerId: user.id,
+    ownerName: user.name,
+    title,
+    members: [
+      { userId: user.id, name: user.name, role: "owner", email: user.email },
+    ],
+  };
+
+  const { error } = await supabase.from("books").insert([newBook]);
+  if (error) throw error;
+  
+  return newBook;
+};
+
+
 export const supabaseSaveBook = async (book) => {
   if (!supabase) return;
 


### PR DESCRIPTION
Fixes #60

**Changes:**
- **Manage Journals Modal**: Created a new `ManageJournalsModal` which can be opened by clicking the book title pill in the center of the Navbar.
- **Multiple Journals Support**: Users can now view all their owned and shared journals in a scrollable list, instantly switch between them, create brand new journals, and permanently delete journals they own.
- **Supabase Integration**: Wired up the `supabaseCreateNewBook` and `supabaseDeleteBook` functions to the database backend, ensuring that full UI sync works across devices.
- **Mobile Page Actions**: Fixed the responsive classes in the `Navbar`. The "Add Pages" and "Tear" buttons are no longer completely hidden on mobile viewports; their text labels are hidden but the icons remain cleanly accessible next to the title pill, giving full control over pages on mobile.
